### PR TITLE
Request with token

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ m.postgrest.init("http://api.foo.com/v1")
 
 This will create two functions:
 
-  * m.postgrest.authenticate - which should be used to request and store a token so we can make calls with authentication.
   * m.postgrest.request - which should be used for anonymous API calls.
+  * m.postgrest.requestWithToken - which should be used for authenticated API calls.
 
 After authentication ```m.postgrest.request``` is redefined to use the JWT in it's header.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ you can just initialize without any argument.
 
 To use an API available at ```http://api.foo.com/v1``` you can use the code:
 ```javascript
-m.postgrest.init("http://api.foo.com/v1")
+m.postgrest.init("http://api.foo.com/v1", {method: "GET", url: "/authentication_endpoint"});
 ```
 
 This will create two functions:
@@ -24,4 +24,12 @@ This will create two functions:
   * m.postgrest.request - which should be used for anonymous API calls.
   * m.postgrest.requestWithToken - which should be used for authenticated API calls.
 
-After authentication ```m.postgrest.request``` is redefined to use the JWT in it's header.
+Both functions are just proxies for mithril's ```m.request``` and will return in the same fashion.
+
+However, the ```m.postgrest.requestWithToken``` stores the JWT for api authentication in the localStorage key "postgrest.token".
+
+To logout of the API and erase the token from the browser localStorage you should call:
+
+```javascript
+m.postgrest.reset();
+```

--- a/spec/authenticate.spec.js
+++ b/spec/authenticate.spec.js
@@ -4,6 +4,7 @@ describe("m.postgrest.authenticate", function(){
 
   beforeEach(function(){
     m.postgrest.reset();
+    m.postgrest.init("", {method: "GET", url: authentication_endpoint});
     var then = function(callback){
       callback({token: token});
     };
@@ -12,7 +13,7 @@ describe("m.postgrest.authenticate", function(){
 
   describe("when token is not in localStorage", function(){
     beforeEach(function(){
-      m.postgrest.authenticate({method: "GET", url: authentication_endpoint});
+      m.postgrest.authenticate();
     });
 
     it("should store the token in localStorage", function(){
@@ -30,7 +31,7 @@ describe("m.postgrest.authenticate", function(){
     });
 
     it("should return a promisse with the token in the data parameter", function(){
-      var promisse = m.postgrest.authenticate({method: "GET", url: authentication_endpoint});
+      var promisse = m.postgrest.authenticate();
       promisse.then(function(data){
         expect(data.token).toEqual(token);
       });

--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -1,4 +1,4 @@
-describe("m.postgrest.init", function(){
+describe("m.postgrest.init & m.postgrest.request", function(){
   var apiPrefix = "http://api.foo.com/v1/";
 
   beforeEach(function(){
@@ -8,6 +8,6 @@ describe("m.postgrest.init", function(){
 
   it("should append api prefix used on init to request url", function(){
     m.postgrest.request({method: "GET", url: "pages.json"});
-    expect(m.request).toHaveBeenCalledWith({method: "GET", url: apiPrefix + "pages.json", config: jasmine.any(Function)});
+    expect(m.request).toHaveBeenCalledWith({method: "GET", url: apiPrefix + "pages.json"});
   });
 });

--- a/spec/requestWithToken.spec.js
+++ b/spec/requestWithToken.spec.js
@@ -1,4 +1,4 @@
-describe("m.postgrest.request", function(){
+describe("m.postgrest.requestWithToken", function(){
   var apiPrefix = "http://api.foo.com/v1/";
   var token = "authentication token";
   var authentication_endpoint = "/authentication_endpoint"
@@ -25,7 +25,7 @@ describe("m.postgrest.request", function(){
         xhr.setRequestHeader("Content-Type", "application/json");
       };
       
-      m.postgrest.request({method: "GET", url: "pages.json", config: xhrConfig});
+      m.postgrest.requestWithToken({method: "GET", url: "pages.json", config: xhrConfig});
       expect(m.request).toHaveBeenCalledWith({method: "GET", url: apiPrefix + "pages.json", config: jasmine.any(Function)});
       expect(xhr.setRequestHeader).toHaveBeenCalledWith("Content-Type", "application/json");
     });
@@ -33,7 +33,7 @@ describe("m.postgrest.request", function(){
 
   describe("when I'm not authenticated", function(){
     it("should call m.request using API prefix", function(){
-      m.postgrest.request({method: "GET", url: "pages.json"});
+      m.postgrest.requestWithToken({method: "GET", url: "pages.json"});
       expect(m.request).toHaveBeenCalledWith({method: "GET", url: apiPrefix + "pages.json", config: jasmine.any(Function)});
     });
   });
@@ -41,7 +41,7 @@ describe("m.postgrest.request", function(){
   describe("when I have already the authentication token", function(){
     beforeEach(function(){
       localStorage.setItem("postgrest.token", token);
-      m.postgrest.request({method: "GET", url: "pages.json"});
+      m.postgrest.requestWithToken({method: "GET", url: "pages.json"});
     });
 
     it("should call m.request using API prefix and authorization header", function(){
@@ -50,3 +50,4 @@ describe("m.postgrest.request", function(){
     });
   });
 });
+

--- a/spec/requestWithTokenCallbacks.spec.js
+++ b/spec/requestWithTokenCallbacks.spec.js
@@ -1,0 +1,41 @@
+describe("m.postgrest.requestWithToken callbacks order", function(){
+  var apiPrefix = "http://api.foo.com/v1/", 
+      token = "authentication token",
+      authentication_endpoint = "/authentication_endpoint",
+      requestResult = 'request result',
+      authenticateTime = 10,
+      requestTime = 5;
+
+  beforeEach(function(){
+    m.postgrest.reset();
+    m.postgrest.init(apiPrefix, {method: "GET", url: authentication_endpoint});
+
+    spyOn(m.postgrest, 'authenticate').and.callFake(function(){
+      var deferred = m.deferred();
+      setTimeout(function(){
+        localStorage.setItem("postgrest.token", token);
+        deferred.resolve({token: token});
+      }, authenticateTime);
+      return deferred.promise;
+    }); 
+
+    spyOn(m.postgrest, 'request').and.callFake(function(options){
+      // Ensure that the token was set before we call the request
+      expect(localStorage.getItem("postgrest.token")).toEqual(token);
+      var deferred = m.deferred();
+      setTimeout(function(){
+        deferred.resolve(requestResult);
+      }, requestTime);
+      return deferred.promise;
+    });
+  });
+
+  it("should call authenticate, then the request and handle the request result in the returning promise", function(done){
+    m.postgrest.requestWithToken({method: "GET", url: "pages.json"}).then(function(data){
+      expect(data).toEqual(requestResult);
+      done();
+    });
+    expect(m.postgrest.authenticate).toHaveBeenCalled();
+  });
+
+});

--- a/spec/reset.spec.js
+++ b/spec/reset.spec.js
@@ -1,0 +1,12 @@
+describe("m.postgrest.reset", function(){
+
+  beforeEach(function(){
+    localStorage.setItem("postgrest.token", 'any token');
+    m.postgrest.reset();
+  });
+
+  it("should remove token from localStorage", function(){
+    expect(localStorage.getItem("postgrest.token")).toEqual(null);
+  });
+});
+

--- a/src/mithril.postgrest.js
+++ b/src/mithril.postgrest.js
@@ -10,9 +10,7 @@
   var postgrest = {};
 
   var xhrConfig = function(xhr){
-    if(token()){
-      xhr.setRequestHeader("Authorization", "Bearer " + token());
-    }
+    xhr.setRequestHeader("Authorization", "Bearer " + token());
     return xhr;
   };
 

--- a/src/mithril.postgrest.js
+++ b/src/mithril.postgrest.js
@@ -26,8 +26,12 @@
 
   postgrest.init = function(apiPrefix){
     postgrest.request = function(options){
+      return m.request(_.extend(options, {url: apiPrefix + options.url}));
+    };
+
+    postgrest.requestWithToken = function(options){
       var config = _.isFunction(options.config) ? _.compose(options.config, xhrConfig) : xhrConfig;
-      return m.request(_.extend(options, {url: apiPrefix + options.url, config: config}));
+      return m.postgrest.request(_.extend(options, {config: config}));
     };
   };
 

--- a/src/mithril.postgrest.js
+++ b/src/mithril.postgrest.js
@@ -28,8 +28,10 @@
     };
 
     postgrest.requestWithToken = function(options){
-      var config = _.isFunction(options.config) ? _.compose(options.config, xhrConfig) : xhrConfig;
-      return m.postgrest.request(_.extend(options, {config: config}));
+      return m.postgrest.authenticate().then(function(data){
+        var config = _.isFunction(options.config) ? _.compose(options.config, xhrConfig) : xhrConfig;
+        return m.postgrest.request(_.extend(options, {config: config}));
+      });
     };
 
     postgrest.authenticate = function(){

--- a/src/mithril.postgrest.js
+++ b/src/mithril.postgrest.js
@@ -22,7 +22,7 @@
     localStorage.removeItem("postgrest.token");
   };
 
-  postgrest.init = function(apiPrefix){
+  postgrest.init = function(apiPrefix, authenticationOptions){
     postgrest.request = function(options){
       return m.request(_.extend(options, {url: apiPrefix + options.url}));
     };
@@ -31,20 +31,21 @@
       var config = _.isFunction(options.config) ? _.compose(options.config, xhrConfig) : xhrConfig;
       return m.postgrest.request(_.extend(options, {config: config}));
     };
-  };
 
-  postgrest.authenticate = function(options){
-    var deferred = m.deferred();
-    if(token()){
-      deferred.resolve({token: token()});
-    }
-    else{
-      m.request(options).then(function(data){
-        localStorage.setItem("postgrest.token", data.token);
-        deferred.resolve({token: data.token});
-      });  
-    }
-    return deferred.promise;
+    postgrest.authenticate = function(){
+      var deferred = m.deferred();
+      if(token()){
+        deferred.resolve({token: token()});
+      }
+      else{
+        m.request(authenticationOptions).then(function(data){
+          localStorage.setItem("postgrest.token", data.token);
+          deferred.resolve({token: data.token});
+        });  
+      }
+      return deferred.promise;
+    };
+    return postgrest;
   };
 
   m.postgrest = postgrest;


### PR DESCRIPTION
* Now we have a function ```requestWithToken``` that will always call authenticate and wait for the result before proceding to the request.
* The ```request``` method does not need to mess with request headers.
* The ```authenticate``` method uses options already defined in the ```init```, we make the assumption that the authentication method varies for each apiPrefix, but not for each call of authenticate.
* The authenticate is always handled by the requestWithToken, so we do not expose it just to make testing and debugging easier.