### PR TITLE
Changes the m.postgrest.loader interface to make it just like the model shortcut functions

### DIFF
--- a/spec/loader.spec.js
+++ b/spec/loader.spec.js
@@ -9,7 +9,7 @@ describe("m.postgrest.loader", function(){
       expect(vm()).toEqual(true);
       return {then: then};
     });
-    vm = m.postgrest.loader({}, m.request);
+    vm = m.postgrest.loader({});
   });
 
   it("should create vm as a getter/setter", function() {


### PR DESCRIPTION
Loader now always uses m.request and loaderWithToken uses requestWithToken